### PR TITLE
Fix yet another issue allowing players to destroy end portals

### DIFF
--- a/src/com/sbezboro/standardplugin/listeners/DispenseListener.java
+++ b/src/com/sbezboro/standardplugin/listeners/DispenseListener.java
@@ -2,6 +2,10 @@ package com.sbezboro.standardplugin.listeners;
 
 import com.sbezboro.standardplugin.StandardPlugin;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.material.Dispenser;
+import org.bukkit.material.MaterialData;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockDispenseEvent;
@@ -16,6 +20,15 @@ public class DispenseListener extends EventListener implements Listener {
 	public void onBlockDispense(BlockDispenseEvent event) {
 		if (event.getItem().getType() == Material.LAVA_BUCKET) {
 			event.setCancelled(true);
+		}
+		
+		if (event.getItem().getType() == Material.WATER_BUCKET) {
+			MaterialData facingData = event.getBlock().getState().getData();
+			BlockFace face = ((Dispenser)facingData).getFacing();
+			Block targetBlock = event.getBlock().getRelative(face);
+			if (targetBlock.getType() == Material.ENDER_PORTAL) {
+				event.setCancelled(true);
+			}
 		}
 	}
 


### PR DESCRIPTION
Using a dispenser containing a water bucket to place a water source block directly into a portal block will destroy said portal block. This fix prevents exactly that.
