### PR TITLE
note when player dies while in PVP, and count this as a PVP kill

### DIFF
--- a/src/com/sbezboro/standardplugin/StandardPlugin.java
+++ b/src/com/sbezboro/standardplugin/StandardPlugin.java
@@ -188,6 +188,7 @@ public class StandardPlugin extends JavaPlugin {
 	private void registerEvents() {
 		PluginManager pluginManager = getServer().getPluginManager();
 		pluginManager.registerEvents(new DeathListener(this), this);
+		pluginManager.registerEvents(new ResurrectListener(this), this);
 		pluginManager.registerEvents(new PlayerJoinListener(this), this);
 		pluginManager.registerEvents(new PlayerLeaveListener(this), this);
 		pluginManager.registerEvents(new PlayerInteractListener(this), this);

--- a/src/com/sbezboro/standardplugin/listeners/BlockBreakListener.java
+++ b/src/com/sbezboro/standardplugin/listeners/BlockBreakListener.java
@@ -21,10 +21,16 @@ public class BlockBreakListener extends EventListener implements Listener {
 	@SuppressWarnings("serial")
 	private static final HashSet<Material> MINABLE_ORES = new HashSet<Material>() {{
 		add(Material.DIAMOND_ORE);
+		add(Material.DEEPSLATE_DIAMOND_ORE);
 		add(Material.EMERALD_ORE);
+		add(Material.DEEPSLATE_EMERALD_ORE);
 		add(Material.COAL_ORE);
+		add(Material.DEEPSLATE_COAL_ORE);
 		add(Material.REDSTONE_ORE);
+		add(Material.DEEPSLATE_REDSTONE_ORE);
 		add(Material.LAPIS_ORE);
+		add(Material.DEEPSLATE_LAPIS_ORE);
+
 		add(Material.NETHER_QUARTZ_ORE);
 	}};
 	
@@ -48,12 +54,15 @@ public class BlockBreakListener extends EventListener implements Listener {
 		
 		StandardPlayer player = plugin.getStandardPlayer(event.getPlayer());
 		ItemStack tool = player.getItemInHand();
-		
+
 		// Track this ore discovery if breaking this block yields the raw material
+		// Note that COPPER_ORE, IRON_ORE, and GOLD_ORE could be added to the leaderboards,
+		// (+ DEEPSLATE_ versions) because they now also drop the raw material
 		if (!tool.getEnchantments().containsKey(Enchantment.SILK_TOUCH)
 				&& MINABLE_ORES.contains(block.getType())) {
-			String type = block.getType().toString();
-			
+			String type = block.getType().toString().replace("DEEPSLATE_", "");
+			plugin.getLogger().info("Block broken, type: " + block.getType() + " -> " + type);
+
 			OreDiscoveryEvent ev = new OreDiscoveryEvent(player, type, location);
 			ev.log();
 		}

--- a/src/com/sbezboro/standardplugin/listeners/CreatureSpawnListener.java
+++ b/src/com/sbezboro/standardplugin/listeners/CreatureSpawnListener.java
@@ -23,7 +23,9 @@ public class CreatureSpawnListener extends EventListener implements Listener {
 		add(EntityType.CHICKEN);
 		add(EntityType.PIG);
 		add(EntityType.SHEEP);
-		add(EntityType.VILLAGER);
+		add(EntityType.TURTLE);  // turtle farms can become very large
+		add(EntityType.COD);
+		add(EntityType.SALMON);
 	}};
 
 	public CreatureSpawnListener(StandardPlugin plugin) {
@@ -45,8 +47,7 @@ public class CreatureSpawnListener extends EventListener implements Listener {
 			}
 		}
 
-		// Temprorarily disable
-		if (false && CONTROLLED_ENTITIES.contains(entity.getType())) {
+		if (CONTROLLED_ENTITIES.contains(entity.getType())) {
 			Location location = entity.getLocation();
 			Chunk chunk = location.getChunk();
 

--- a/src/com/sbezboro/standardplugin/listeners/PlayerLeaveListener.java
+++ b/src/com/sbezboro/standardplugin/listeners/PlayerLeaveListener.java
@@ -2,6 +2,7 @@ package com.sbezboro.standardplugin.listeners;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -14,6 +15,8 @@ import com.sbezboro.standardplugin.integrations.SimplyVanishIntegration;
 import com.sbezboro.standardplugin.model.StandardPlayer;
 import com.sbezboro.standardplugin.model.Title;
 import com.sbezboro.standardplugin.net.LeaveHttpRequest;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
 
 public class PlayerLeaveListener extends EventListener implements Listener {
 
@@ -44,6 +47,24 @@ public class PlayerLeaveListener extends EventListener implements Listener {
 					plugin.getStandardPlayerByUUID(player.getLastAttackerUuid()).getDisplayName(), ChatColor.RED));
 
 			if (player.hasTitle(Title.PVP_LOGGER)) {
+
+				// check if holding a totem, and remove if so
+				PlayerInventory inv = player.getInventory();
+
+				boolean had_totem = false;
+
+				// check twice because of main hand / off hand
+				if (inv.getItemInMainHand().getType() == Material.TOTEM_OF_UNDYING) {
+					inv.setItemInMainHand(null);
+					had_totem = true;
+				}
+				if (inv.getItemInOffHand().getType() == Material.TOTEM_OF_UNDYING) {
+					inv.setItemInOffHand(null);
+					had_totem = true;
+				}
+
+				if (had_totem) StandardPlugin.broadcast(String.format("%s%s%s lost a totem as well", ChatColor.AQUA, player.getDisplayName(), ChatColor.RED));
+
 				player.damage(1000.0);
 			}
 		}

--- a/src/com/sbezboro/standardplugin/listeners/ResurrectListener.java
+++ b/src/com/sbezboro/standardplugin/listeners/ResurrectListener.java
@@ -1,0 +1,38 @@
+package com.sbezboro.standardplugin.listeners;
+
+import com.sbezboro.http.HttpRequestManager;
+import com.sbezboro.standardplugin.model.StandardPlayer;
+import com.sbezboro.standardplugin.net.DeathHttpRequest;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.*;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityResurrectEvent;
+
+import com.sbezboro.standardplugin.StandardPlugin;
+
+public class ResurrectListener extends EventListener implements Listener {
+
+	public ResurrectListener(StandardPlugin plugin) {
+		super(plugin);
+	}
+
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	public void onEntityResurrect(EntityResurrectEvent event) {
+		LivingEntity entity = event.getEntity();
+		StandardPlayer player = plugin.getStandardPlayer(entity);
+
+		if (player.wasInPvp()) {
+			StandardPlayer attacker = plugin.getStandardPlayerByUUID(player.getLastAttackerUuid());
+
+			StandardPlugin.broadcast(String.format("%sA totem of " + player.getDisplayName() + " was popped by " + attacker.getDisplayName(), ChatColor.RED), true, true);
+
+			// also log this as a kill, code copied from private DeathEvent::log
+			HttpRequestManager.getInstance().startRequest(
+					new DeathHttpRequest(player.getUuidString(), "player", attacker.getUuidString()));
+
+		}  // if totem was popped while in PVP
+	}
+
+}


### PR DESCRIPTION

a small tweak for fairer PVP results

note no spawn kill checks / power loss computation is done,
it just shows more info in the chat, and does the extra API call to log the kill

(not that important for a fairly rare kill situation anyway)
